### PR TITLE
docsをsubmoduleとして読み込むように設定変更

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -73,12 +73,12 @@
       "source": "${localWorkspaceFolder}",
       "target": "${containerWorkspaceFolder}",
       "type": "bind"
-    },
-    {
-      "source": "${localWorkspaceFolder}/../papas-docs",
-      "target": "${containerWorkspaceFolder}/papas-docs",
-      "type": "bind"
     }
+    // {
+    //   "source": "${localWorkspaceFolder}/../papas-docs",
+    //   "target": "${containerWorkspaceFolder}/papas-docs",
+    //   "type": "bind"
+    // }
   ],
   // Gitのソース管理でdocsを表示させない設定
   "workspaceFolder": "/workspace"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Git Submoduleで管理しているドキュメントフォルダ
+docs/
+
+# Docker関連
+Dockerfile
+Dockerfile.dev
+.dockerignore
+
+# Git関連
+.git
+.gitattributes
+.gitignore
+.gitmodules
+
+# 開発環境設定
+.devcontainer/
+.vscode/
+
+# Pythonキャッシュ
+__pycache__/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs"]
+	path = docs
+	url = git@github.com:tech0-gen10-papas/papas-docs.git


### PR DESCRIPTION
これでどちらのリポジトリからもdocsリポジトリを読み込み・変更することができ、docsはdocsリポジトリとしてGit管理できるようになる。